### PR TITLE
Upgrade test.check

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :distribution :repo
             :comments     "Copyright 2011-2014 Pedro Santos All Rights Reserved."}
 
-  :dependencies [[org.clojure/test.check "0.7.0"]
+  :dependencies [[org.clojure/test.check "0.8.0"]
                  [org.clojure/math.numeric-tower "0.0.4"]
                  [org.clojure/tools.namespace "0.2.11"]
                  [org.clojure/clojure "1.8.0-alpha2"]

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [criterium "0.4.3"]
                  [reagent "0.5.0"]
                  [secretary "1.2.3"]
-                 [org.clojure/clojurescript "1.7.28"]]
+                 [org.clojure/clojurescript "1.7.48"]]
 
   :jvm-opts ["-XX:+TieredCompilation"]
 

--- a/src/obb_rules/logger.cljc
+++ b/src/obb_rules/logger.cljc
@@ -3,7 +3,7 @@
   "Specific logger that can be turned on and off"
   (:require [obb-rules.simplifier :as simplify]))
 
-(def ^:dynamic *verbose* true)
+(def ^:dynamic *verbose* false)
 
 #?(:clj
   (defmacro log

--- a/test/obb_rules/actions/auto_deploy_test.cljc
+++ b/test/obb_rules/actions/auto_deploy_test.cljc
@@ -7,13 +7,12 @@
             [obb-rules.result :as result]
             [obb-rules.action :as action]
             [obb-rules.generators :as obb-gen]
-    #?(:cljs [cljs.test.check :as tc])
-    #?(:clj [clojure.test.check.generators :as gen]
-       :cljs [cljs.test.check.generators :as gen])
+            [clojure.test.check.generators :as gen]
+   #?(:cljs [clojure.test.check :as tc])
     #?(:clj [clojure.test.check.properties :as prop]
-       :cljs [cljs.test.check.properties :as prop :include-macros true])
+       :cljs [clojure.test.check.properties :as prop :include-macros true])
     #?(:clj [clojure.test.check.clojure-test :refer [defspec]]
-       :cljs [cljs.test.check.cljs-test :refer-macros [defspec]])
+       :cljs [clojure.test.check.clojure-test :refer-macros [defspec]])
     #?(:clj [clojure.test :refer [deftest testing is run-tests]]
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 

--- a/test/obb_rules/ai/acts_as_bot_test.cljc
+++ b/test/obb_rules/ai/acts_as_bot_test.cljc
@@ -5,13 +5,12 @@
             [obb-rules.element :as element]
             [obb-rules.unit :as unit]
             [obb-rules.result :as result]
-    #?(:cljs [cljs.test.check :as tc])
-    #?(:clj [clojure.test.check.generators :as gen]
-       :cljs [cljs.test.check.generators :as gen])
+            [clojure.test.check.generators :as gen]
+   #?(:cljs [clojure.test.check :as tc])
     #?(:clj [clojure.test.check.properties :as prop]
-       :cljs [cljs.test.check.properties :as prop :include-macros true])
+       :cljs [clojure.test.check.properties :as prop :include-macros true])
     #?(:clj [clojure.test.check.clojure-test :refer [defspec]]
-       :cljs [cljs.test.check.cljs-test :refer-macros [defspec]])
+       :cljs [clojure.test.check.clojure-test :refer-macros [defspec]])
     #?(:clj [clojure.test :refer [deftest testing is run-tests]]
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 

--- a/test/obb_rules/ai/alamo_test.cljc
+++ b/test/obb_rules/ai/alamo_test.cljc
@@ -11,13 +11,12 @@
             [obb-rules.ai.alamo :as alamo]
             [obb-rules.generators :as obb-gen]
             [obb-rules.ai.acts-as-bot-test :as acts-as-bot]
-    #?(:cljs [cljs.test.check :as tc])
-    #?(:clj [clojure.test.check.generators :as gen]
-       :cljs [cljs.test.check.generators :as gen])
+            [clojure.test.check.generators :as gen]
+   #?(:cljs [clojure.test.check :as tc])
     #?(:clj [clojure.test.check.properties :as prop]
-       :cljs [cljs.test.check.properties :as prop :include-macros true])
+       :cljs [clojure.test.check.properties :as prop :include-macros true])
     #?(:clj [clojure.test.check.clojure-test :refer [defspec]]
-       :cljs [cljs.test.check.cljs-test :refer-macros [defspec]])
+       :cljs [clojure.test.check.clojure-test :refer-macros [defspec]])
     #?(:clj [clojure.test :refer [deftest testing is run-tests]]
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 

--- a/test/obb_rules/ai/common_test.cljc
+++ b/test/obb_rules/ai/common_test.cljc
@@ -9,13 +9,12 @@
             [obb-rules.generators :as obb-gen]
             [obb-rules.game :as game]
             [obb-rules.ai.common :as common]
-    #?(:cljs [cljs.test.check :as tc])
-    #?(:clj [clojure.test.check.generators :as gen]
-       :cljs [cljs.test.check.generators :as gen])
+            [clojure.test.check.generators :as gen]
+   #?(:cljs [clojure.test.check :as tc])
     #?(:clj [clojure.test.check.properties :as prop]
-       :cljs [cljs.test.check.properties :as prop :include-macros true])
+       :cljs [clojure.test.check.properties :as prop :include-macros true])
     #?(:clj [clojure.test.check.clojure-test :refer [defspec]]
-       :cljs [cljs.test.check.cljs-test :refer-macros [defspec]])
+       :cljs [clojure.test.check.clojure-test :refer-macros [defspec]])
     #?(:clj [clojure.test :refer [deftest testing is run-tests]]
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 

--- a/test/obb_rules/ai/firingsquad_test.cljc
+++ b/test/obb_rules/ai/firingsquad_test.cljc
@@ -10,13 +10,12 @@
             [obb-rules.ai.firingsquad :as firingsquad]
             [obb-rules.generators :as obb-gen]
             [obb-rules.ai.acts-as-bot-test :as acts-as-bot]
-    #?(:cljs [cljs.test.check :as tc])
-    #?(:clj [clojure.test.check.generators :as gen]
-       :cljs [cljs.test.check.generators :as gen])
+            [clojure.test.check.generators :as gen]
+   #?(:cljs [clojure.test.check :as tc])
     #?(:clj [clojure.test.check.properties :as prop]
-       :cljs [cljs.test.check.properties :as prop :include-macros true])
+       :cljs [clojure.test.check.properties :as prop :include-macros true])
     #?(:clj [clojure.test.check.clojure-test :refer [defspec]]
-       :cljs [cljs.test.check.cljs-test :refer-macros [defspec]])
+       :cljs [clojure.test.check.clojure-test :refer-macros [defspec]])
     #?(:clj [clojure.test :refer [deftest testing is run-tests]]
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 

--- a/test/obb_rules/evaluator_test.cljc
+++ b/test/obb_rules/evaluator_test.cljc
@@ -8,13 +8,12 @@
             [obb-rules.turn :as turn]
             [obb-rules.generators :as obb-gen]
             [obb-rules.game :as game]
-    #?(:cljs [cljs.test.check :as tc])
-    #?(:clj [clojure.test.check.generators :as gen]
-       :cljs [cljs.test.check.generators :as gen])
+            [clojure.test.check.generators :as gen]
+   #?(:cljs [clojure.test.check :as tc])
     #?(:clj [clojure.test.check.properties :as prop]
-       :cljs [cljs.test.check.properties :as prop :include-macros true])
+       :cljs [clojure.test.check.properties :as prop :include-macros true])
     #?(:clj [clojure.test.check.clojure-test :refer [defspec]]
-       :cljs [cljs.test.check.cljs-test :refer-macros [defspec]])
+       :cljs [clojure.test.check.clojure-test :refer-macros [defspec]])
     #?(:clj [clojure.test :refer [deftest testing is run-tests]]
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 

--- a/test/obb_rules/generators.cljc
+++ b/test/obb_rules/generators.cljc
@@ -7,11 +7,9 @@
             [obb-rules.action :as action]
             [obb-rules.host-dependent :as host]
             [obb-rules.unit :as unit]
-    #?(:clj [clojure.test.check.generators :as gen]
-       :cljs [cljs.test.check.generators :as gen])
-    #?(:clj [clojure.test.check.properties :as prop]
-       :cljs [cljs.test.check.properties :as prop :include-macros true])
-    #?(:clj [clojure.test.check.clojure-test :refer [defspec]])
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+   #?(:cljs [clojure.test.check :as tc])
     #?(:clj [clojure.test :refer [deftest testing is run-tests]]
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 


### PR DESCRIPTION
```
Successfully compiled "build/test/out-node.js" in 13.854 seconds.
Running ClojureScript test: test

/Users/pedrosantos/projects/orionsbelt-battlegrounds/obb-rules/build/test/out-node/clojure/test/check/random/longs.js:41
clojure.test.check.random.longs.ONE = goog.math.Long.getOne();
^
TypeError: Object function (low, high) {
  /**
   * @type {number}
   * @private
   */
  this.low_ = low | 0;  // force into 32 signed bits.

  /**
   * @type {number}
   * @private
   */
  this.high_ = high | 0;  // force into 32 signed bits.
} has no method 'getOne'
  at Object.<anonymous> (/Users/pedrosantos/projects/orionsbelt-battlegrounds/obb-rules/build/test/out-node/clojure/test/check/random/longs.js:41:54)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Module.require (module.js:364:17)
  at require (module.js:380:17)
  at global.CLOSURE_IMPORT_SCRIPT (/Users/pedrosantos/projects/orionsbelt-battlegrounds/obb-rules/build/test/out-node/goog/bootstrap/nodejs.js:75:3)
  at Object.goog.importScript_ (/Users/pedrosantos/projects/orionsbelt-battlegrounds/obb-rules/build/test/out-node/goog/base.js:901:9)
at Object.goog.writeScripts_ (/Users/pedrosantos/projects/orionsbelt-battlegrounds/obb-rules/build/test/out-node/goog/base.js:1326:16)
  Error encountered performing task 'cljsbuild' with profile(s): 'cljs-node'
                                                                  Subprocess failed
```