### PR TITLE
Add implicit phantomjs dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build/
 langs
 *.log
 resources/public/js/compiled*
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "obb-rules",
+  "version": "0.0.1",
+  "description": "OBB Rules",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "phantomjs-prebuilt": "2.1.4"
+  },
+  "author": "OBB"
+}

--- a/project.clj
+++ b/project.clj
@@ -90,7 +90,9 @@
        :plugins [[lein-cljsbuild "1.1.2"]]
 
        :cljsbuild {
-                   :test-commands {"test" ["phantomjs" "phantom/test.js" "test.html"]}
+                   :test-commands {"test" ["./node_modules/phantomjs-prebuilt/bin/phantomjs"
+                                           "phantom/test.js"
+                                           "test.html"]}
                    :builds [{:id "test"
                              :source-paths ["src/obb_rules" "test"]
                              :compiler {:output-to "build/test/out.js"

--- a/script/test
+++ b/script/test
@@ -1,3 +1,4 @@
+npm install
 
 lein with-profile clj deps
 lein with-profile cljs-node deps


### PR DESCRIPTION
An env wihtout phantonjs already installed would fail to run the tests. 
Apparently travis already has it installed. This makes it implicit.