### PR TITLE
Improve Alamo AI

### DIFF
--- a/src/obb_rules/ai/alamo.cljc
+++ b/src/obb_rules/ai/alamo.cljc
@@ -17,7 +17,7 @@
             [obb-rules.board :as board]))
 
 (def element-depth 10)
-(def options-per-element 3)
+(def options-per-element 10)
 
 (defmulti actions
   "Returns a list of actions to apply to the current game"

--- a/src/obb_rules/ai/common.cljc
+++ b/src/obb_rules/ai/common.cljc
@@ -225,3 +225,16 @@
               (update :value + (value-for-join current-option))
               (assoc :cost (+ (master :cost) (current-option :cost))))
           master)))))
+
+(defn aggregate-best
+  "Given a collection of sorted options, tries to group several of them
+  to find the best one"
+  [player options]
+  (let [joiner (partial join-options player)]
+    (->> options
+         (map (fn [master-option]
+                (->> options
+                     (filter #(>= (:cost master-option) (:cost %)))
+                     (reduce joiner master-option))))
+         (sort-by option-value-sorter)
+         first)))

--- a/src/obb_rules/ai/common.cljc
+++ b/src/obb_rules/ai/common.cljc
@@ -153,8 +153,8 @@
          unit (element/element-unit element)
          mov-cost (unit/unit-movement-cost unit)
          player (element/element-player element)
-         possible-coords (take 1 (shuffle (move/find-possible-destinations game element)))
-         run-results (partial go-to-result game element player)
+         possible-coords (take max-options (shuffle (move/find-possible-destinations game element)))
+         run-results (partial goto-result game element player)
          actions-and-results (map run-results possible-coords)]
      (map (fn [[action result target-coord]]
              (-> result

--- a/src/obb_rules/ai/firingsquad.cljc
+++ b/src/obb_rules/ai/firingsquad.cljc
@@ -39,26 +39,6 @@
                            (into (common/move-options game element))
                            (->> (sort-by common/option-value-cost-sorter)))))))
 
-(defn- find-one
-  "Given a collection of sorted options, tries to find a good one"
-  [player options]
-  (let [joiner (partial common/join-options player)
-        the-one (reduce joiner (first options) (rest options))]
-    the-one))
-
-(defn- aggregate-best
-  "Given a collection of sorted options, tries to group several of them
-  to find the best one"
-  [player options]
-  (let [joiner (partial common/join-options player)]
-    (->> options
-         (map (fn [master-option]
-                (->> options
-                     (filter #(>= (:cost master-option) (:cost %)))
-                     (reduce joiner master-option))))
-         (sort-by common/option-value-sorter)
-         first)))
-
 (defn turn-option
   "Gets the complete option for playing on a specific game"
   [game player]
@@ -67,7 +47,7 @@
     (->> (reduce gatherer [] elements)
          (sort-by common/option-value-sorter)
          #_(logger)
-         (aggregate-best player))))
+         (common/aggregate-best player))))
 
 (defmethod actions :turn
   [game player]

--- a/src/obb_rules/host_dependent.cljc
+++ b/src/obb_rules/host_dependent.cljc
@@ -17,3 +17,13 @@
 
 (defn scenarios-to-test []
   (parse-int (get-env "OBB_SCENARIOS_TO_TEST" "1")))
+
+#?(:clj
+    (def parallel-map
+      "Tries to run a map in parallel"
+      pmap))
+
+#?(:cljs
+    (def parallel-map
+      "Tries to run a map in parallel"
+      map))

--- a/test/obb_rules/ai/alamo_test.cljc
+++ b/test/obb_rules/ai/alamo_test.cljc
@@ -48,12 +48,16 @@
 (deftest prefer-the-star
   (acts-as-bot/prefer-the-star alamo/actions))
 
+(def pretorian (unit/get-unit-by-name "pretorian"))
+(def pretorian-element-p2 (element/create-element :p2 pretorian 100 :south))
 (def crusader (unit/get-unit-by-name "crusader"))
 (def crusader-element-p2 (element/create-element :p2 crusader 25 :south))
 (def doomer (unit/get-unit-by-name "doomer"))
 (def doomer-element-p2 (element/create-element :p2 doomer 25 :south))
 (def kamikaze (unit/get-unit-by-name "kamikaze"))
 (def kamikaze-element-p1 (element/create-element :p1 kamikaze 100 :north))
+(def anubis (unit/get-unit-by-name "anubis"))
+(def anubis-element-p1 (element/create-element :p1 anubis 5 :north))
 
 (deftest chooses-the-most-defensive-option
   (let [board (-> (game-progress/new-game {} {:mode :annihilation})
@@ -67,6 +71,30 @@
         game (result/result-board result)]
     (is (result/succeeded? result))
     (is (board/get-element game [2 3]))))
+
+(deftest runs-away
+  (let [board (-> (board/create-board)
+                  (game/state :p1)
+                  (board/place-element [2 2] crusader-element-p2)
+                  (board/place-element [2 3] anubis-element-p1))
+        actions (alamo/actions board :p1)
+        result (turn/process-actions board :p1 actions)
+        game (result/result-board result)]
+    (is (result/succeeded? result))
+    (is (board/get-element game [2 2]))
+    (is (not (board/get-element game [2 3])))))
+
+(deftest kamikaze-dont-front-attack-pretorian
+  (let [board (-> (board/create-board)
+                  (game/state :p1)
+                  (board/place-element [2 2] pretorian-element-p2)
+                  (board/place-element [6 6] kamikaze-element-p1))
+        actions (alamo/actions board :p1)
+        result (turn/process-actions board :p1 actions)
+        game (result/result-board result)]
+    (is (result/succeeded? result))
+    (is (= 1 (count (board/board-elements game :p1))))
+    (is (= 1 (count (board/board-elements game :p2))))))
 
 (deftest alamo-vs-alamo
   (println "Running" obb-gen/scenarions-to-test "alamo vs alamo")


### PR DESCRIPTION
Alamo AI is a bot that, for each possible option to perform, will run
firingsquad against it to update the value of the option. This makes it
much more defensive.
