### PR TITLE
Add Supernova game mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v3.0.0 - 26/03/2016
+* Support Supernova game mode
+* Move all game progress logic to the `game-progress` namespace
+
 ### v2.1.0 - ???
 * Added writer and reader to serialize to a simple text format
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ You can create a game with a given _stash_ for each player. A stash is an
 associative collection with the units and corresponding quantities to deploy.
 
 ```clojure
-(def game (obb-rules.game/new-game {:p1 stash :p2 stash})
+(def stash (obb-rules.stash/create :rain 1 
+                                   :crusader 2))
+(def game (obb-rules.game-progress/new-game {:p1 stash :p2 stash})
 ;=> {:state :deploy, :stash {:p2 {:crusader 2, :rain 1}, :p1 {:crusader 2, :rain 1}}, :width 8, :height 8, :elements {}}
 ```
 
@@ -84,7 +86,7 @@ Or you can just create a game with a random stash. In this case, the same random
 stash is given to all players.
 
 ```clojure
-(obb-rules.game/random)
+(obb-rules.game-progress/new-random-game)
 ;=> {:state :deploy, :stash {:p2 {"toxic" 100, "anubis" 100, "heavy-seeker" 25, "nova" 25, "kamikaze" 50, "scarab" 50, "worm" 50, "crusader" 25}, :p1 {"toxic" 100, "anubis" 100, "heavy-seeker" 25, "nova" 25, "kamikaze" 50, "scarab" 50, "worm" 50, "crusader" 25}}, :width 8, :height 8, :elements {}}
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,16 +72,16 @@ Add the following dependency to your `project.clj` file:
 
 ## Usage
 
-You can create a game with a given _stash_. A stash is the quantity of units available to deploy.
+You can create a game with a given _stash_ for each player. A stash is an
+associative collection with the units and corresponding quantities to deploy.
 
 ```clojure
-(def stash (obb-rules.stash/create :rain 1 
-                                   :crusader 2))
-(def game (obb-rules.game/create stash)
+(def game (obb-rules.game/new-game {:p1 stash :p2 stash})
 ;=> {:state :deploy, :stash {:p2 {:crusader 2, :rain 1}, :p1 {:crusader 2, :rain 1}}, :width 8, :height 8, :elements {}}
 ```
 
-Or you can just create a game with a random stash.
+Or you can just create a game with a random stash. In this case, the same random
+stash is given to all players.
 
 ```clojure
 (obb-rules.game/random)

--- a/src/obb_demo/processor.cljs
+++ b/src/obb_demo/processor.cljs
@@ -15,15 +15,23 @@
   "Creates a new game"
   []
   (game/random)
-  #_(-> (stash/create :rain 100
-                    :raptor 100
-                    :pretorian 40
-                    :vector 40
-                    :eagle 50
-                    :kamikaze 50
-                    :fenix 25
-                    :crusader 25)
-      (game/create)))
+  #_(-> {:p1 (stash/create :rain 100
+                           :raptor 100
+                           :pretorian 40
+                           :vector 40
+                           :eagle 50
+                           :kamikaze 50
+                           :fenix 25
+                           :crusader 25)
+         :p2 (stash/create :rain 100
+                           :raptor 100
+                           :pretorian 40
+                           :vector 40
+                           :eagle 50
+                           :kamikaze 50
+                           :fenix 25
+                           :crusader 25)}
+      (game/new-game)))
 
 (defn deployed-game
   "Creates a deployed game"

--- a/src/obb_demo/processor.cljs
+++ b/src/obb_demo/processor.cljs
@@ -1,6 +1,7 @@
 (ns obb-demo.processor
   (:require [obb-demo.state :as state]
             [obb-rules.game :as game]
+            [obb-rules.game-progress :as game-progress]
             [obb-rules.stash :as stash]
             [obb-rules.math :as math]
             [obb-rules.simplifier :as simplifier]
@@ -14,7 +15,7 @@
 (defn- new-game
   "Creates a new game"
   []
-  (game/random)
+  (game-progress/new-random-game)
   #_(-> {:p1 (stash/create :rain 100
                            :raptor 100
                            :pretorian 40
@@ -31,7 +32,7 @@
                            :kamikaze 50
                            :fenix 25
                            :crusader 25)}
-      (game/new-game)))
+      (game-progress/new-game)))
 
 (defn deployed-game
   "Creates a deployed game"

--- a/src/obb_rules/ai/alamo.cljc
+++ b/src/obb_rules/ai/alamo.cljc
@@ -149,7 +149,7 @@
 (defmethod actions :turn
   [game player]
   (logger/ai-turn "alamo" game)
-  (let [elements (board/board-elements game player)
+  (let [elements (board/player-elements game player)
         gatherer (partial gather-element-actions game)
         option (->> (reduce gatherer [] elements)
                     (sort-by common/option-value-sorter)

--- a/src/obb_rules/ai/firingsquad.cljc
+++ b/src/obb_rules/ai/firingsquad.cljc
@@ -62,7 +62,7 @@
 (defn turn-option
   "Gets the complete option for playing on a specific game"
   [game player]
-  (let [elements (board/board-elements game player)
+  (let [elements (board/player-elements game player)
           gatherer (partial gather-element-actions game)]
     (->> (reduce gatherer [] elements)
          (sort-by common/option-value-sorter)

--- a/src/obb_rules/board.cljc
+++ b/src/obb_rules/board.cljc
@@ -2,6 +2,7 @@
   (:require [obb-rules.math :as math]
             [obb-rules.laws :as laws]
             [obb-rules.element :as element]
+            [obb-rules.unit :as unit]
             [obb-rules.simplifier :as simplify]))
 
 (defn- random-terrain
@@ -30,6 +31,12 @@
   (->> (board :elements)
        (filter (partial element-from-player? player))
        (map #(last %))))
+
+(defn unit-present?
+  "Checks whether the given unit is present and belongs to the given player"
+  [board player unit]
+  (some #(= (-> %1 element/element-unit unit/unit-name) unit)
+        (player-elements board player)))
 
 (defn board-elements-count
   "Gets the number of board elements"

--- a/src/obb_rules/board.cljc
+++ b/src/obb_rules/board.cljc
@@ -19,16 +19,16 @@
    :terrain (random-terrain)
    :elements {}}))
 
-(defn- player-element?
+(defn- element-from-player?
   "True if the given element is from the given player"
   [player [coordinate element]]
-  (simplify/name= player (element/element-player element)))
+  (element/player? element player))
 
-(defn board-elements
-  "Gets the elements of a given player"
+(defn player-elements
+  "Gets the elements belonging to a given player"
   [board player]
   (->> (board :elements)
-       (filter (partial player-element? player))
+       (filter (partial element-from-player? player))
        (map #(last %))))
 
 (defn board-elements-count
@@ -36,7 +36,7 @@
   ([board]
    (count (board :elements)))
   ([board player]
-   (count (board-elements board player))))
+   (count (player-elements board player))))
 
 (defn empty-board?
   "Checks if a board is empty"

--- a/src/obb_rules/element.cljc
+++ b/src/obb_rules/element.cljc
@@ -16,7 +16,7 @@
 (defn element-player
   "Element's player"
   ([element]
-   (:player element))
+   (keyword (:player element)))
   ([element player]
    (assoc element :player player)))
 
@@ -46,8 +46,8 @@
   (let [unit (element-unit element)]
     (unit/unit-range unit)))
 
-(defn element-direction 
-  "Gets/Sets element's direction" 
+(defn element-direction
+  "Gets/Sets element's direction"
   ([element] (element :direction))
   ([element new-direction]
    (assoc element :direction new-direction)))
@@ -192,6 +192,11 @@
   "Unfreezes an element"
   [element]
   (dissoc element :frozen))
+
+(defn player?
+  "Checks whether the element belongs to the given player"
+  [element player]
+  (= (element-player element) player))
 
 (defn assert-element
   "Assets that an object acts as an element"

--- a/src/obb_rules/evaluator.cljc
+++ b/src/obb_rules/evaluator.cljc
@@ -15,8 +15,10 @@
   [game player]
   (let [stash (game/get-stash game player)]
     (if (stash/cleared? stash)
-      (map (fn [e] [(element/element-unit e) (element/element-quantity e)]) (board/board-elements game player))
-      (map (fn [[k v]] [(unit/fetch k) v]) stash))))
+      (map (fn [e] [(element/element-unit e) (element/element-quantity e)])
+           (board/player-elements game player))
+      (map (fn [[k v]] [(unit/fetch k) v])
+           stash))))
 
 (defn- sum-value
   "Sums the value/quantity of the given units"

--- a/src/obb_rules/game.cljc
+++ b/src/obb_rules/game.cljc
@@ -109,3 +109,9 @@
   are all successful."
   [game]
   (every? #(result/succeeded? (last %)) (action-results game)))
+
+(defn update-stash
+  "Updates the specified player's stash by applying f to the stash and the given args"
+  [game player f & f-args]
+  (let [stash (board/get-stash game player)]
+    (board/set-stash game player (apply f stash f-args))))

--- a/src/obb_rules/game.cljc
+++ b/src/obb_rules/game.cljc
@@ -7,7 +7,7 @@
 
 (def version "3.0.0")
 
-(def ^:private possible-players [:p1 :p2])
+(def all-players [:p1 :p2])
 
 (defn state?
   "Checks if the game is in a given state"
@@ -48,7 +48,7 @@
   (let [stash (stash/random)]
     (-> (reduce (fn [assigned-stashes player] (assoc assigned-stashes player stash))
                 {}
-                possible-players)
+                all-players)
         new-game)))
 
 (defn start-battle

--- a/src/obb_rules/game.cljc
+++ b/src/obb_rules/game.cljc
@@ -9,6 +9,10 @@
 
 (def all-players [:p1 :p2])
 
+(def ^:private available-modes #{:annihilation :supernova})
+
+(def ^:private default-create-options {:mode :annihilation})
+
 (defn state?
   "Checks if the game is in a given state"
   [game state]
@@ -21,7 +25,11 @@
 (defn final? "True if the game has ended" [game] (state? game :final))
 (defn player-turn? "True if player's state" [game player] (state? game player))
 (defn get-stash "Gets the player's stash" [game player] (board/get-stash game player))
-(defn mode "Gets the game mode" [game] (or (game :mode) :default))
+
+(defn mode
+  "Gets the game mode"
+  [game]
+  (:mode game))
 
 (defn state
   "Gets/Sets the current game's state"
@@ -29,6 +37,22 @@
    (game :state))
   ([game new-state]
    (assoc game :state new-state)))
+
+(defn- merge-create-defaults
+  "Returns the options with the default values applied for the non-specified options"
+  [options]
+  (merge default-create-options options))
+
+(defn- valid-mode?
+  "Checks if the given mode is one of the supported modes"
+  [mode]
+  (contains? available-modes mode))
+
+(defn- choose-mode
+  "Sets the game in the given mode"
+  [game mode]
+  (assert (valid-mode? mode) "Unknown mode")
+  (assoc game :mode mode))
 
 (defn new-game
   "Creates a game for the given stashes.
@@ -40,6 +64,7 @@
                  stashes)
       (cond->
         (some? (:terrain options)) (board/board-terrain (:terrain options)))
+      (choose-mode (:mode (merge-create-defaults options)))
       (state :deploy)))
 
 (defn random
@@ -85,4 +110,3 @@
   are all successful."
   [game]
   (every? #(result/succeeded? (last %)) (action-results game)))
-

--- a/src/obb_rules/game.cljc
+++ b/src/obb_rules/game.cljc
@@ -5,7 +5,9 @@
             [obb-rules.host-dependent :as host]
             [obb-rules.board :as board]))
 
-(def version "2.0.0")
+(def version "3.0.0")
+
+(def ^:private possible-players [:p1 :p2])
 
 (defn state?
   "Checks if the game is in a given state"
@@ -28,33 +30,26 @@
   ([game new-state]
    (assoc game :state new-state)))
 
-(defn create
-  "Creates a game for a given stash"
-  ([stash]
-    (create stash stash))
-  ([stash1 stash2]
-   (-> (board/create-board)
-       (board/set-stash :p1 stash1)
-       (board/set-stash :p2 stash2)
-       (assoc :state :deploy))))
-
 (defn new-game
   "Creates a game for the given stashes.
   stashes is an associative collection in which the keys correspond to the
   players and the values to the corresponding stash."
   [stashes & [{:as options} :as args]]
   (-> (reduce-kv (fn [board player stash] (board/set-stash board player stash))
-                             (board/create-board)
-                             stashes)
+                 (board/create-board)
+                 stashes)
       (cond->
         (some? (:terrain options)) (board/board-terrain (:terrain options)))
       (state :deploy)))
 
 (defn random
-  "Creates a game with random units"
+  "Creates a game with a random stash. The same stash is user for all players."
   []
   (let [stash (stash/random)]
-    (create stash)))
+    (-> (reduce (fn [assigned-stashes player] (assoc assigned-stashes player stash))
+                {}
+                possible-players)
+        new-game)))
 
 (defn start-battle
   "Given a deployed board, starts the battle"

--- a/src/obb_rules/game.cljc
+++ b/src/obb_rules/game.cljc
@@ -3,11 +3,10 @@
             [obb-rules.result :as result]
             [obb-rules.simplifier :as simplify]
             [obb-rules.host-dependent :as host]
+            [obb-rules.player :as player]
             [obb-rules.board :as board]))
 
 (def version "3.0.0")
-
-(def all-players [:p1 :p2])
 
 (def ^:private available-modes #{:annihilation :supernova})
 
@@ -73,7 +72,7 @@
   (let [stash (stash/random)]
     (-> (reduce (fn [assigned-stashes player] (assoc assigned-stashes player stash))
                 {}
-                all-players)
+                player/all-players)
         new-game)))
 
 (defn start-battle

--- a/src/obb_rules/game.cljc
+++ b/src/obb_rules/game.cljc
@@ -10,8 +10,6 @@
 
 (def ^:private available-modes #{:annihilation :supernova})
 
-(def ^:private default-create-options {:mode :annihilation})
-
 (defn state?
   "Checks if the game is in a given state"
   [game state]
@@ -25,11 +23,6 @@
 (defn player-turn? "True if player's state" [game player] (state? game player))
 (defn get-stash "Gets the player's stash" [game player] (board/get-stash game player))
 
-(defn mode
-  "Gets the game mode"
-  [game]
-  (:mode game))
-
 (defn state
   "Gets/Sets the current game's state"
   ([game]
@@ -37,43 +30,18 @@
   ([game new-state]
    (assoc game :state new-state)))
 
-(defn- merge-create-defaults
-  "Returns the options with the default values applied for the non-specified options"
-  [options]
-  (merge default-create-options options))
-
 (defn- valid-mode?
   "Checks if the given mode is one of the supported modes"
   [mode]
   (contains? available-modes mode))
 
-(defn- choose-mode
-  "Sets the game in the given mode"
-  [game mode]
-  (assert (valid-mode? mode) "Unknown mode")
-  (assoc game :mode mode))
-
-(defn new-game
-  "Creates a game for the given stashes.
-  stashes is an associative collection in which the keys correspond to the
-  players and the values to the corresponding stash."
-  [stashes & [{:as options} :as args]]
-  (-> (reduce-kv (fn [board player stash] (board/set-stash board player stash))
-                 (board/create-board)
-                 stashes)
-      (cond->
-        (some? (:terrain options)) (board/board-terrain (:terrain options)))
-      (choose-mode (:mode (merge-create-defaults options)))
-      (state :deploy)))
-
-(defn random
-  "Creates a game with a random stash. The same stash is user for all players."
-  []
-  (let [stash (stash/random)]
-    (-> (reduce (fn [assigned-stashes player] (assoc assigned-stashes player stash))
-                {}
-                player/all-players)
-        new-game)))
+(defn mode
+  "Gets or sets the game mode"
+  ([game]
+   (:mode game))
+  ([game mode]
+   (assert (valid-mode? mode) "Unknown mode")
+   (assoc game :mode mode)))
 
 (defn start-battle
   "Given a deployed board, starts the battle"
@@ -91,7 +59,7 @@
   (:first-player game))
 
 (defn action-results
-  "Provides the actions a results currently aplied on this game
+  "Provides the actions results currently applied on this game
   if any."
   [game]
   (game :action-results))

--- a/src/obb_rules/game_mode.cljc
+++ b/src/obb_rules/game_mode.cljc
@@ -15,10 +15,13 @@
 (defn winner
   "Gets the winner of the given game"
   [game]
-  (cond
-    (board/empty-board? game :p1) :p2
-    (board/empty-board? game :p2) :p1
-    :else :none))
+  (let [[first & others :as players-with-units] (filter
+                                                 #(not (board/empty-board? game %))
+                                                 game/all-players)]
+    (cond
+      (empty? players-with-units) :draw
+      (empty? others)             first
+      :else                       :none)))
 
 (defn- winner?
   "Checks if there is already a winner"

--- a/src/obb_rules/game_mode.cljc
+++ b/src/obb_rules/game_mode.cljc
@@ -12,15 +12,6 @@
           stash2 (game/get-stash game :p2)]
       (and (stash/cleared? stash1) (stash/cleared? stash2)))))
 
-(defn final?
-  "Checks if the game is finished"
-  [game]
-  (and
-    (not (= (keyword (game/state game)) :deploy))
-    (or
-      (board/empty-board? game :p1)
-      (board/empty-board? game :p2))))
-
 (defn winner
   "Gets the winner of the given game"
   [game]
@@ -28,6 +19,18 @@
     (board/empty-board? game :p1) :p2
     (board/empty-board? game :p2) :p1
     :else :none))
+
+(defn- winner?
+  "Checks if there is already a winner"
+  [game]
+  (not= (winner game) :none))
+
+(defn final?
+  "Checks if the game is finished"
+  [game]
+  (and
+   (not (game/deploy? game))
+   (winner? game)))
 
 (defn- finalize
   "Marks a game as final"

--- a/src/obb_rules/game_mode.cljc
+++ b/src/obb_rules/game_mode.cljc
@@ -1,7 +1,8 @@
 (ns obb-rules.game-mode
   (:require [obb-rules.board :as board]
             [obb-rules.stash :as stash]
-            [obb-rules.player :as player]))
+            [obb-rules.player :as player]
+            [obb-rules.game :as game]))
 
 (defn winner
   "Gets the winner of the given game"
@@ -19,3 +20,18 @@
   [game]
   (not= (winner game) :none))
 
+(defn- add-star-units
+  [game]
+  (reduce #(game/update-stash %1 %2 stash/add-units {:star 1})
+          game
+          player/all-players))
+
+(defmulti on-new-game
+  "Hook to run mode specific preparation on game creation"
+  (fn [game] (:mode game)))
+
+(defmethod on-new-game :supernova
+  [game]
+  (add-star-units game))
+
+(defmethod on-new-game :annihilation [game] game)

--- a/src/obb_rules/game_mode.cljc
+++ b/src/obb_rules/game_mode.cljc
@@ -1,67 +1,21 @@
 (ns obb-rules.game-mode
   (:require [obb-rules.board :as board]
             [obb-rules.stash :as stash]
-            [obb-rules.game :as game]))
-
-(defn deploy-completed?
-  "True if it's on deploy and completed"
-  [game]
-  (if-not (game/deploy? game)
-    game
-    (let [stash1 (game/get-stash game :p1)
-          stash2 (game/get-stash game :p2)]
-      (and (stash/cleared? stash1) (stash/cleared? stash2)))))
+            [obb-rules.player :as player]))
 
 (defn winner
   "Gets the winner of the given game"
   [game]
   (let [[first & others :as players-with-units] (filter
                                                  #(not (board/empty-board? game %))
-                                                 game/all-players)]
+                                                 player/all-players)]
     (cond
       (empty? players-with-units) :draw
       (empty? others)             first
       :else                       :none)))
 
-(defn- winner?
+(defn winner?
   "Checks if there is already a winner"
   [game]
   (not= (winner game) :none))
 
-(defn end-game?
-  "Checks if the game is finished"
-  [game]
-  (and
-   (not (game/deploy? game))
-   (winner? game)))
-
-(defn- finalize
-  "Marks a game as final"
-  [game]
-  (game/state game :final))
-
-(defn- start-game
-  "Starts the game"
-  [game]
-  (game/start-battle game))
-
-(defn- switch-turn-player?
-  "Checks if the game is in a state where a player switch should be done"
-  [game]
-  (some #{:p1 :p2} [(keyword (game :state))]))
-
-(defn- switch-turn-player
-  "Toggles the player to play"
-  [game]
-  (let [current-player (keyword (game :state))
-        next-player (first (disj #{:p1 :p2} current-player))]
-    (assoc game :state (keyword next-player))))
-
-(defn process
-  "Checks the current game's state and acts based on it"
-  [game]
-  (cond
-    (end-game? game)           (finalize game)
-    (switch-turn-player? game) (switch-turn-player game)
-    (deploy-completed? game)   (start-game game)
-    :else                      game))

--- a/src/obb_rules/game_mode.cljc
+++ b/src/obb_rules/game_mode.cljc
@@ -28,7 +28,7 @@
   [game]
   (not= (winner game) :none))
 
-(defn final?
+(defn end-game?
   "Checks if the game is finished"
   [game]
   (and
@@ -61,7 +61,7 @@
   "Checks the current game's state and acts based on it"
   [game]
   (cond
-    (final? game) (finalize game)
+    (end-game? game)           (finalize game)
     (switch-turn-player? game) (switch-turn-player game)
-    (deploy-completed? game) (start-game game)
-    :else game))
+    (deploy-completed? game)   (start-game game)
+    :else                      game))

--- a/src/obb_rules/game_progress.cljc
+++ b/src/obb_rules/game_progress.cljc
@@ -21,7 +21,7 @@
    stashes is an associative collection in which the keys correspond to the
    players and the values to the corresponding stash."
   [stashes & [{:as options} :as args]]
-  (-> (reduce-kv (fn [board player stash] (board/set-stash board player stash))
+  (-> (reduce-kv board/set-stash
                  (board/create-board)
                  stashes)
       (cond->

--- a/src/obb_rules/game_progress.cljc
+++ b/src/obb_rules/game_progress.cljc
@@ -1,9 +1,13 @@
-(ns obb-rules.game-progress
-  (:require[obb-rules.stash :as stash]
-           [obb-rules.game :as game]
-           [obb-rules.player :as player]
-           [obb-rules.game-mode :as game-mode]
-           [obb-rules.board :as board]))
+(ns ^{:added "3.0.0"
+      :author "Joaquim Torres"}
+  obb-rules.game-progress
+  "Evolving a game through its different stages"
+
+  (:require [obb-rules.stash :as stash]
+            [obb-rules.game :as game]
+            [obb-rules.player :as player]
+            [obb-rules.game-mode :as game-mode]
+            [obb-rules.board :as board]))
 
 (def ^:private default-new-game-options {:mode :annihilation})
 

--- a/src/obb_rules/game_progress.cljc
+++ b/src/obb_rules/game_progress.cljc
@@ -1,0 +1,54 @@
+(ns obb-rules.game-progress
+  (:require[obb-rules.stash :as stash]
+           [obb-rules.game :as game]
+           [obb-rules.game-mode :as game-mode]))
+
+(defn deploy-completed?
+  "True if it's on deploy and completed"
+  [game]
+  (if-not (game/deploy? game)
+    game
+    (let [stash1 (game/get-stash game :p1)
+          stash2 (game/get-stash game :p2)]
+      (and (stash/cleared? stash1) (stash/cleared? stash2)))))
+
+(defn end-game?
+  "Checks if the game is finished"
+  [game]
+  (and
+   (not (game/deploy? game))
+   (game-mode/winner? game)))
+
+(defn- end-game
+  "Changes a game to final state"
+  [game]
+  (game/state game :final))
+
+(defn- start-game
+  "Starts the game"
+  [game]
+  (game/start-battle game))
+
+(defn- switch-turn-player?
+  "Checks if the game is in a state where a player switch should be done"
+  [game]
+  (some #{:p1 :p2} [(keyword (game :state))]))
+
+(defn- switch-turn-player
+  "Toggles the player to play"
+  [game]
+  (let [current-player (keyword (game :state))
+        next-player (first (disj #{:p1 :p2} current-player))]
+    (assoc game :state (keyword next-player))))
+
+(defn next-stage
+  "Moves the game to the next stage based on the current conditions"
+  [game]
+  (cond
+    (end-game? game)           (end-game game)
+    (switch-turn-player? game) (switch-turn-player game)
+    (deploy-completed? game)   (start-game game)
+    :else                      game))
+
+
+

--- a/src/obb_rules/player.cljc
+++ b/src/obb_rules/player.cljc
@@ -1,4 +1,6 @@
-(ns obb-rules.player)
+(ns ^{:added "3.0.0"
+      :author "Joaquim Torres"}
+    obb-rules.player
+    "Player data functions")
 
 (def all-players [:p1 :p2])
-

--- a/src/obb_rules/player.cljc
+++ b/src/obb_rules/player.cljc
@@ -1,0 +1,4 @@
+(ns obb-rules.player)
+
+(def all-players [:p1 :p2])
+

--- a/src/obb_rules/privatize.cljc
+++ b/src/obb_rules/privatize.cljc
@@ -20,7 +20,7 @@
   [board player viewed-by]
   (if (= player viewed-by)
     board
-    (let [elements (board/board-elements board player)
+    (let [elements (board/player-elements board player)
           remover (partial remove-element player)]
       (reduce remover board elements))))
 

--- a/src/obb_rules/serializer/reader.cljc
+++ b/src/obb_rules/serializer/reader.cljc
@@ -5,12 +5,12 @@
   (:require [clojure.string :as string]
             [obb-rules.serializer.common :as common]
             [obb-rules.game :as game]
+            [obb-rules.game-progress :as game-progress]
             [obb-rules.result :as result]
             [obb-rules.board :as board]
             [obb-rules.turn :as turn]
             [obb-rules.host-dependent :as host]
-            [obb-rules.actions.deploy :as deploy-action]
-            [obb-rules.game-mode :as game-mode]))
+            [obb-rules.actions.deploy :as deploy-action]))
 
 (defn- get-int
   "Given a string, gets the char on the specific position, and returns it
@@ -163,6 +163,6 @@
         stash1 (build-stash attrs :p1 p1-deploy)
         stash2 (build-stash attrs :p2 p2-deploy)
         turn-history (str->history-items (nth parts 2 nil))]
-    (-> (game/new-game {:p1 stash1 :p2 stash2} attrs)
+    (-> (game-progress/new-game {:p1 stash1 :p2 stash2} attrs)
         (turn/process-history deploy-history)
         (start-battle attrs turn-history))))

--- a/src/obb_rules/stash.cljc
+++ b/src/obb_rules/stash.cljc
@@ -63,3 +63,8 @@
         heavies (random-by-category 3 :heavy 25)
         all (concat lights mediums heavies)]
     (apply create all)))
+
+(defn add-units
+  "Adds the units to the given stash"
+  [stash units]
+  (merge-with + stash units))

--- a/src/obb_rules/turn.cljc
+++ b/src/obb_rules/turn.cljc
@@ -2,7 +2,7 @@
   (:require [obb-rules.action :as action]
             [obb-rules.game :as game]
             [obb-rules.laws :as laws]
-            [obb-rules.game-mode :as game-mode]
+            [obb-rules.game-progress :as game-progress]
             [obb-rules.result :as result]))
 
 (defn- continue-apply-actions
@@ -100,7 +100,7 @@
   (let [actions (map action-pair raw-actions)
         do-actions (partial apply-actions player)
         final-state (reduce do-actions game actions)
-        final (game-mode/process final-state)
+        final (game-progress/next-stage final-state)
         action-points (points final)]
     (create-result final player action-points)))
 

--- a/src/obb_rules/unit.cljc
+++ b/src/obb_rules/unit.cljc
@@ -18,7 +18,8 @@
             [obb-rules.units.toxic]
             [obb-rules.units.anubis]
             [obb-rules.units.kamikaze]
-            [obb-rules.units.crusader]))
+            [obb-rules.units.crusader]
+            [obb-rules.units.star]))
 
 (defrecord ^{:doc "Represents a combat unit"} CombatUnit
   [name code value
@@ -49,12 +50,13 @@
      obb-rules.units.panther/metadata
      obb-rules.units.scarab/metadata
      obb-rules.units.kamikaze/metadata
-     obb-rules.units.crusader/metadata]))
+     obb-rules.units.crusader/metadata
+     obb-rules.units.star/metadata]))
 
 (def get-units (memoize gather-units))
 
 (defn- build-units
-  [units, selector]
+  [units selector]
   (reduce #(conj %1 [(selector %2) %2]) {} units))
 
 (def ^:private units-by-name (delay (build-units (get-units) :name)))

--- a/src/obb_rules/units/star.cljc
+++ b/src/obb_rules/units/star.cljc
@@ -1,4 +1,7 @@
-(ns obb-rules.units.star)
+(ns ^{:added "3.0.0"
+      :author "Joaquim Torres"}
+    obb-rules.units.star
+    "Metadata for the Star unit")
 
 (def metadata
   {:name "star"

--- a/src/obb_rules/units/star.cljc
+++ b/src/obb_rules/units/star.cljc
@@ -1,0 +1,17 @@
+(ns obb-rules.units.star)
+
+(def metadata
+  {:name "star"
+   :code "st"
+
+   :attack 1
+   :defense 10000
+   :range 1
+   :value 50000
+
+   :type :mechanic
+   :category :special
+   :displacement :air
+
+   :movement-type :all
+   :movement-cost 1})

--- a/test/obb_rules/actions/auto_deploy_test.cljc
+++ b/test/obb_rules/actions/auto_deploy_test.cljc
@@ -1,6 +1,7 @@
 (ns obb-rules.actions.auto-deploy-test
   (:require [obb-rules.actions.auto-deploy :as auto-deploy]
             [obb-rules.game :as game]
+            [obb-rules.game-progress :as game-progress]
             [obb-rules.board :as board]
             [obb-rules.stash :as stash]
             [obb-rules.turn :as turn]
@@ -23,30 +24,30 @@
     (action board player)))
 
 (deftest fails-if-not-deploy-state
-  (let [game (-> (game/random) (game/state :p1))
+  (let [game (-> (game-progress/new-random-game) (game/state :p1))
         result (process-action game :p1 [:auto-deploy])]
     (is (result/failed? result))
     (is (= "MustBeDeployState" (result/result-message result)))))
 
 (deftest fails-if-no-stash
-  (let [board (-> (game/random) (board/set-stash :p1 {}))
+  (let [board (-> (game-progress/new-random-game) (board/set-stash :p1 {}))
         result (process-action board :p1 [:auto-deploy])]
     (is (result/failed? result))
     (is (= "NoStash" (result/result-message result)))))
 
 (deftest fails-if-no-template
-  (let [board (game/random)
+  (let [board (game-progress/new-random-game)
         result (process-action board :p1 [:auto-deploy :no-template])]
     (is (result/failed? result))
     (is (= "NoTemplate" (result/result-message result)))))
 
 (deftest smoke-success-str
-  (let [board (game/random)
+  (let [board (game-progress/new-random-game)
         result (process-action board "p1" ["auto-deploy" "firingsquad"])]
     (is (result/succeeded? result))))
 
 (deftest smoke-success-sym
-  (let [board (game/random)
+  (let [board (game-progress/new-random-game)
         result-p2 (process-action board :p2 [:auto-deploy :firingsquad])
         board2 (result/result-board result-p2)
         result-p1 (process-action board2 :p1 [:auto-deploy :firingsquad])]
@@ -58,9 +59,9 @@
 (defn- auto-deploy-for
   "Auto deploys for both players for the given stash"
   [stash deploy-template]
-  (let [board (game/new-game {:p1 stash :p2 stash})
+  (let [board     (game-progress/new-game {:p1 stash :p2 stash})
         result-p2 (process-action board :p2 [:auto-deploy deploy-template])
-        board2 (result/result-board result-p2)
+        board2    (result/result-board result-p2)
         result-p1 (process-action board2 :p1 [:auto-deploy deploy-template])]
     (is (result/succeeded? result-p1))
     (is (result/succeeded? result-p2))

--- a/test/obb_rules/actions/auto_deploy_test.cljc
+++ b/test/obb_rules/actions/auto_deploy_test.cljc
@@ -58,7 +58,7 @@
 (defn- auto-deploy-for
   "Auto deploys for both players for the given stash"
   [stash deploy-template]
-  (let [board (game/create stash)
+  (let [board (game/new-game {:p1 stash :p2 stash})
         result-p2 (process-action board :p2 [:auto-deploy deploy-template])
         board2 (result/result-board result-p2)
         result-p1 (process-action board2 :p1 [:auto-deploy deploy-template])]

--- a/test/obb_rules/ai/acts_as_bot_test.cljc
+++ b/test/obb_rules/ai/acts_as_bot_test.cljc
@@ -87,7 +87,7 @@
 (defn first-blood
   "Deploy and attack"
   [botfn stash]
-  (let [board (game/create stash)
+  (let [board (game/new-game {:p1 stash :p2 stash})
         actions (botfn board :p1)
         result (turn/process-actions board :p1 actions)
         result2 (turn/process-actions (result/result-board result) :p2 actions)

--- a/test/obb_rules/ai/acts_as_bot_test.cljc
+++ b/test/obb_rules/ai/acts_as_bot_test.cljc
@@ -32,7 +32,7 @@
 (defn direct-attack
   "Simple direct attack"
   [botfn]
-  (let [board (-> (board/create-board)
+  (let [board (-> (game-progress/new-game {})
                   (game/state :p1)
                   (board/place-element [2 5] (element/create-element :p1 rain 1 :south [2 5]))
                   (board/place-element [2 6] (element/create-element :p2 rain 1 :north [2 6])))
@@ -45,7 +45,7 @@
 (defn direct-attack-double
   "Must select two actions"
   [botfn]
-  (let [board (-> (board/create-board)
+  (let [board (-> (game-progress/new-game {})
                   (game/state :p1)
                   (board/place-element [2 5] (element/create-element :p1 rain 10 :south [2 5]))
                   (board/place-element [2 6] (element/create-element :p2 rain 10 :north [2 6]))
@@ -60,7 +60,7 @@
 (defn rotate-attack
   "Rotates to attack"
   [botfn]
-  (let [board (-> (board/create-board)
+  (let [board (-> (game-progress/new-game {})
                   (game/state :p1)
                   (board/place-element [2 5] (element/create-element :p1 rain 1 :south [2 5]))
                   (board/place-element [3 5] (element/create-element :p2 rain 1 :north [3 5])))
@@ -73,7 +73,7 @@
 (defn prefer-rotate-attack
   "Scenario where preferes rotates to attack"
   [botfn]
-  (let [board (-> (board/create-board)
+  (let [board (-> (game-progress/new-game {})
                   (game/state :p1)
                   (board/place-element [2 5] (element/create-element :p1 rain 1 :south [2 5]))
                   (board/place-element [2 6] (element/create-element :p2 rain 1 :south [2 6]))
@@ -103,7 +103,7 @@
 (defn move-and-attack
   "Moves and attacks"
   [botfn]
-  (let [board (-> (board/create-board)
+  (let [board (-> (game-progress/new-game {})
                   (game/state :p1)
                   (board/place-element [2 5] (element/create-element :p1 rain 1 :south [2 5]))
                   (board/place-element [5 5] (element/create-element :p2 kamikaze 1 :north [5 5])))
@@ -116,7 +116,7 @@
 (defn seek-and-destroy
   "The seek part"
   [botfn]
-  (let [board (-> (board/create-board)
+  (let [board (-> (game-progress/new-game {})
                   (game/state :p1)
                   (board/place-element [2 5] (element/create-element :p1 rain 1 :south [2 5]))
                   (board/place-element [5 5] (element/create-element :p1 kamikaze 1 :north [5 5])))

--- a/test/obb_rules/ai/acts_as_bot_test.cljc
+++ b/test/obb_rules/ai/acts_as_bot_test.cljc
@@ -1,5 +1,6 @@
 (ns obb-rules.ai.acts-as-bot-test
   (:require [obb-rules.game :as game]
+            [obb-rules.game-progress :as game-progress]
             [obb-rules.turn :as turn]
             [obb-rules.board :as board]
             [obb-rules.element :as element]
@@ -23,7 +24,7 @@
 (defn validate-deploy
   "Applies a bot function to a deployable game"
   [botfn]
-  (let [game (game/random)
+  (let [game (game-progress/new-random-game)
         actions (botfn game :p1)
         result (turn/process-actions game :p1 actions)]
     (is (result/succeeded? result))))
@@ -87,7 +88,7 @@
 (defn first-blood
   "Deploy and attack"
   [botfn stash]
-  (let [board (game/new-game {:p1 stash :p2 stash})
+  (let [board (game-progress/new-game {:p1 stash :p2 stash})
         actions (botfn board :p1)
         result (turn/process-actions board :p1 actions)
         result2 (turn/process-actions (result/result-board result) :p2 actions)

--- a/test/obb_rules/ai/alamo_test.cljc
+++ b/test/obb_rules/ai/alamo_test.cljc
@@ -1,5 +1,6 @@
 (ns obb-rules.ai.alamo-test
   (:require [obb-rules.game :as game]
+            [obb-rules.game-progress :as game-progress]
             [obb-rules.turn :as turn]
             [obb-rules.stash :as stash]
             [obb-rules.unit :as unit]
@@ -68,7 +69,7 @@
   (println "Running" obb-gen/scenarions-to-test "alamo vs alamo")
   (dotimes [x obb-gen/scenarions-to-test]
     (time
-      (let [game (-> (game/random)
+      (let [game (-> (game-progress/new-random-game)
                      (turn/process-actions :p1 [[:auto-deploy :firingsquad]])
                      (result/result-board)
                      (turn/process-actions :p2 [[:auto-deploy :firingsquad]])

--- a/test/obb_rules/ai/alamo_test.cljc
+++ b/test/obb_rules/ai/alamo_test.cljc
@@ -53,7 +53,7 @@
 (def kamikaze-element-p1 (element/create-element :p1 kamikaze 100 :north))
 
 (deftest chooses-the-most-defensive-option
-  (let [board (-> (board/create-board)
+  (let [board (-> (game-progress/new-game {})
                   (game/state :p1)
                   (board/place-element [2 2] crusader-element-p2)
                   (board/place-element [2 3] doomer-element-p2)

--- a/test/obb_rules/ai/bugs/bug_16.cljc
+++ b/test/obb_rules/ai/bugs/bug_16.cljc
@@ -12,6 +12,7 @@
 (def game {:width 8,
            :height 8,
            :terrain :forest,
+           :mode :annihilation,
            :elements
            {[7 1]
             {:player :p2,

--- a/test/obb_rules/ai/bugs/bug_21.cljc
+++ b/test/obb_rules/ai/bugs/bug_21.cljc
@@ -13,6 +13,7 @@
             :cljs [cljs.test :refer-macros [deftest testing is]])))
 
 (def game {:width 8,
+           :mode :annihilation,
            :height 8,
            :terrain :terrest,
            :elements

--- a/test/obb_rules/ai/firingsquad_test.cljc
+++ b/test/obb_rules/ai/firingsquad_test.cljc
@@ -54,7 +54,7 @@
 (def quantity 100)
 
 (deftest complete-game
-  (let [board (-> (board/create-board)
+  (let [board (-> (game-progress/new-game {})
                   (game/state :p1)
                   (board/place-element [1 7] (element/create-element :p1 crusader quantity :north [1 7]))
                   (board/place-element [2 7] (element/create-element :p1 crusader quantity :north [2 7]))
@@ -105,7 +105,7 @@
 
 (defn- crusader-vs-crusader
   []
-  (-> (board/create-board)
+  (-> (game-progress/new-game {})
       (game/state :p1)
       (board/place-element [1 7] (element/create-element :p1 crusader quantity :north [1 7]))
       (board/place-element [2 7] (element/create-element :p1 crusader quantity :north [2 7]))

--- a/test/obb_rules/ai/firingsquad_test.cljc
+++ b/test/obb_rules/ai/firingsquad_test.cljc
@@ -1,5 +1,6 @@
 (ns obb-rules.ai.firingsquad-test
   (:require [obb-rules.game :as game]
+            [obb-rules.game-progress :as game-progress]
             [obb-rules.turn :as turn]
             [obb-rules.stash :as stash]
             [obb-rules.unit :as unit]
@@ -78,7 +79,7 @@
   (println "Running" obb-gen/scenarions-to-test "firingsquad vs firingsquad")
   (dotimes [x obb-gen/scenarions-to-test]
     (time
-      (let [game (-> (game/random)
+      (let [game (-> (game-progress/new-random-game)
                      (turn/process-actions :p1 [[:auto-deploy :firingsquad]])
                      (result/result-board)
                      (turn/process-actions :p2 [[:auto-deploy :firingsquad]])

--- a/test/obb_rules/board_test.cljc
+++ b/test/obb_rules/board_test.cljc
@@ -92,3 +92,15 @@
     (is (board/get-element focus1 [1 1]))
     (is (= 3 (board/board-elements-count focus2)))
     (is (board/get-element focus2 [2 1]))))
+
+(deftest player-elements-sequence
+  (let [e1 (element/create-element :p1 (unit/get-unit-by-name "rain") 20 :south [1 1])
+        e2 (element/create-element :p2 (unit/get-unit-by-name "rain") 20 :north [2 1])
+        board (-> (board/create-board)
+                  (board/place-element [1 1] e1)
+                  (board/place-element [2 1] e2))]
+    (testing "elements belong to the given player"
+      (is (= [e1] (board/player-elements board :p1))))
+    (testing "empty list of elements"
+      (is (empty? (board/player-elements board :px))))))
+

--- a/test/obb_rules/board_test.cljc
+++ b/test/obb_rules/board_test.cljc
@@ -104,3 +104,15 @@
     (testing "empty list of elements"
       (is (empty? (board/player-elements board :px))))))
 
+(deftest presence-of-an-unit
+  (let [e1 (element/create-element :p1 (unit/get-unit-by-name "rain") 20 :south [1 1])
+        e2 (element/create-element :p2 (unit/get-unit-by-name "crusader") 20 :north [2 1])
+        board (-> (board/create-board)
+                  (board/place-element [1 1] e1)
+                  (board/place-element [2 1] e2))]
+    (testing "player has the given unit"
+      (is (board/unit-present? board :p1 "rain")))
+    (testing "only the opponent has the unit"
+      (is (not (board/unit-present? board :p1 "crusader"))))
+    (testing "player does not have the unit"
+      (is (not (board/unit-present? board :p1 "star"))))))

--- a/test/obb_rules/evaluator_test.cljc
+++ b/test/obb_rules/evaluator_test.cljc
@@ -8,6 +8,7 @@
             [obb-rules.turn :as turn]
             [obb-rules.generators :as obb-gen]
             [obb-rules.game :as game]
+            [obb-rules.game-progress :as game-progress]
             [clojure.test.check.generators :as gen]
    #?(:cljs [clojure.test.check :as tc])
     #?(:clj [clojure.test.check.properties :as prop]
@@ -20,14 +21,14 @@
 (def rain (unit/get-unit-by-name "rain"))
 
 (deftest yields-zero-when-no-elements
-  (let [game-no-units (-> (game/random) (dissoc :stash))
+  (let [game-no-units (-> (game-progress/new-random-game) (dissoc :stash))
         [score1 score2] (evaluator/eval-game game-no-units)]
     (is (= 0 score1))
     (is (= 0 score2))))
 
 (deftest considers-stash
   (let [stash (stash/create :rain 1)
-        game  (game/new-game {:p1 stash :p2 stash})
+        game  (game-progress/new-game {:p1 stash :p2 stash})
         [score1 score2] (evaluator/eval-game game)]
     (is (= 4 score1))
     (is (= 4 score2))))
@@ -44,7 +45,7 @@
   obb-gen/scenarions-to-test-small
   (prop/for-all [raw-stash (obb-gen/stash)]
     (let [stash (stash/create-from-hash (apply hash-map (flatten raw-stash)))
-          game  (game/new-game {:p1 stash :p2 stash})
+          game  (game-progress/new-game {:p1 stash :p2 stash})
           [score1 score2] (evaluator/eval-game game)]
       (is (< 0 score1))
       (is (< 0 score2)))))
@@ -53,7 +54,7 @@
   obb-gen/scenarions-to-test-small
   (prop/for-all [raw-stash (obb-gen/stash)]
     (let [stash (stash/create-from-hash (apply hash-map (flatten raw-stash)))
-          game (-> (game/new-game {:p1 stash :p2 stash})
+          game (-> (game-progress/new-game {:p1 stash :p2 stash})
                    (turn/process :p1 [:auto-deploy :firingsquad])
                    (result/result-board))
           [score1 score2] (evaluator/eval-game game :value)]

--- a/test/obb_rules/evaluator_test.cljc
+++ b/test/obb_rules/evaluator_test.cljc
@@ -27,7 +27,7 @@
 
 (deftest considers-stash
   (let [stash (stash/create :rain 1)
-        game (game/create stash)
+        game  (game/new-game {:p1 stash :p2 stash})
         [score1 score2] (evaluator/eval-game game)]
     (is (= 4 score1))
     (is (= 4 score2))))
@@ -44,7 +44,7 @@
   obb-gen/scenarions-to-test-small
   (prop/for-all [raw-stash (obb-gen/stash)]
     (let [stash (stash/create-from-hash (apply hash-map (flatten raw-stash)))
-          game (game/create stash)
+          game  (game/new-game {:p1 stash :p2 stash})
           [score1 score2] (evaluator/eval-game game)]
       (is (< 0 score1))
       (is (< 0 score2)))))
@@ -53,7 +53,7 @@
   obb-gen/scenarions-to-test-small
   (prop/for-all [raw-stash (obb-gen/stash)]
     (let [stash (stash/create-from-hash (apply hash-map (flatten raw-stash)))
-          game (-> (game/create stash)
+          game (-> (game/new-game {:p1 stash :p2 stash})
                    (turn/process :p1 [:auto-deploy :firingsquad])
                    (result/result-board))
           [score1 score2] (evaluator/eval-game game :value)]

--- a/test/obb_rules/game_mode_test.cljc
+++ b/test/obb_rules/game_mode_test.cljc
@@ -13,38 +13,32 @@
 (def p1-element (element/create-element "p1" rain 20 :south))
 (def p2-element (element/create-element "p2" rain 20 :south))
 (def running-game (-> (game/random)
-                  (assoc :state "p1")
-                  (board/place-element [1 1] p1-element)
-                  (board/place-element [1 2] p2-element)
-                  (game-mode/process)))
+                      (assoc :state "p1")
+                      (board/place-element [1 1] p1-element)
+                      (board/place-element [1 2] p2-element)
+                      (game-mode/process)))
 
-(deftest toogle-state-player-str
-  (let [game (-> running-game
-                 (assoc :state "p1")
-                 (game-mode/process))]
-    (is (= :p2 (get game :state)))))
+(deftest game-processing
+  (testing "switch current player using a string"
+    (let [game (-> running-game
+                   (assoc :state "p1")
+                   (game-mode/process))]
+      (is (= :p2 (get game :state)))))
 
-(deftest toogle-state-player-keyword
-  (let [game (-> running-game
-                 (assoc :state :p1)
-                 (game-mode/process))]
-    (is (= :p2 (get game :state)))))
+  (testing "switch current player using a keyword"
+    (let [game (-> running-game
+                   (assoc :state :p1)
+                   (game-mode/process))]
+      (is (= :p2 (get game :state)))))
 
-(deftest toogle-state-player-keyword-inverted
-  (let [game (-> running-game
-                 (assoc :state :p2)
-                 (game-mode/process))]
-    (is (= :p1 (get game :state)))))
+  (testing "game is not finished while in deploy state"
+    (let [game-on-deploy (game/random)
+          final-game (game-mode/process game-on-deploy)]
+      (is (not (game-mode/final? game-on-deploy)))
+      (is (= :deploy (game/state final-game)))))
 
-(deftest dont-finalize-on-deploy
-  (let [game-on-deploy (game/random)
-        final-game (game-mode/process game-on-deploy)]
-    (is (not (game-mode/final? game-on-deploy)))
-    (is (= :deploy (game/state final-game)))))
-
-(deftest dont-finalize-on-deploy-str
-  (let [game-on-deploy (-> (game/random) (assoc :state "deploy"))
-        final-game (game-mode/process game-on-deploy)]
-    (is (not (game-mode/final? game-on-deploy)))
-    (is (= "deploy" (game/state final-game)))))
-
+  (testing "game is not finished even if it is in deploy state as a string"
+    (let [game-on-deploy (-> (game/random) (assoc :state "deploy"))
+          final-game (game-mode/process game-on-deploy)]
+      (is (not (game-mode/final? game-on-deploy)))
+      (is (= "deploy" (game/state final-game))))))

--- a/test/obb_rules/game_mode_test.cljc
+++ b/test/obb_rules/game_mode_test.cljc
@@ -9,24 +9,43 @@
     #?(:clj [clojure.test :refer [deftest testing is run-tests]]
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 
+(def star (unit/get-unit-by-name "star"))
 (def rain (unit/get-unit-by-name "rain"))
 
-(def p2-element (element/create-element "p2" rain 20 :south))
-
-(def game-with-empty-board (game-progress/new-game {}))
+(def p1-elem (element/create-element :p1 rain 10 :north))
+(def p2-elem (element/create-element :p2 rain 20 :south))
+(def p1-star (element/create-element :p1 star 1 :north))
+(def p2-star (element/create-element :p2 star 1 :south))
 
 (deftest annihilation-winner
-  (testing "draw when all players have an empty board"
-     (is (= :draw (game-mode/winner game-with-empty-board))))
-  (let [game-with-empty-p1 (-> (game-progress/new-game {})
-                               (board/place-element [1 2] p2-element))
-        winner             (game-mode/winner game-with-empty-p1)]
-    (testing "the winner is returned"
-      (is (= :p2 winner)))
-    (testing "the winner does not have an empty board"
-      (is (not (board/empty-board? game-with-empty-p1 winner))))
-    (testing "the loser has an empty board"
-      (is (board/empty-board? game-with-empty-p1 :p1)))))
+  (let [game-with-empty-board (game-progress/new-game {} {:mode :annihilation})]
+    (testing "draw when all players have an empty board"
+      (is (= :draw (game-mode/winner game-with-empty-board))))
+    (let [game-with-empty-p1 (-> (game-progress/new-game {})
+                                 (board/place-element [1 2] p2-elem))
+          winner             (game-mode/winner game-with-empty-p1)]
+      (testing "the winner is returned"
+        (is (= :p2 winner)))
+      (testing "the winner does not have an empty board"
+        (is (not (board/empty-board? game-with-empty-p1 winner))))
+      (testing "the loser has an empty board"
+        (is (board/empty-board? game-with-empty-p1 :p1))))))
+
+(deftest supernova-winner
+  (let [game-with-no-stars (-> (game-progress/new-game {} {:mode :supernova})
+                               (board/place-element [1 2] p1-elem)
+                               (board/place-element [7 1] p2-elem))]
+    (testing "draw when all players have lost their star unit"
+      (is (= :draw (game-mode/winner game-with-no-stars))))
+    (let [game   (-> (game-progress/new-game {} {:mode :supernova})
+                     (board/place-element [1 1] p1-star))
+          winner (game-mode/winner game)]
+      (testing "the winner is returned"
+        (is (= :p1 winner)))
+      (testing "the winner has the star unit"
+        (is (board/unit-present? game winner "star")))
+      (testing "the loser does not have the star unit"
+        (is (not (board/unit-present? game :p2 "star")))))))
 
 (deftest supernova-on-new-game
   (testing "star unit is automatically added to the stash"

--- a/test/obb_rules/game_mode_test.cljc
+++ b/test/obb_rules/game_mode_test.cljc
@@ -36,13 +36,13 @@
   (testing "game is not finished while in deploy state"
     (let [game-on-deploy (game/random)
           final-game (game-mode/process game-on-deploy)]
-      (is (not (game-mode/final? game-on-deploy)))
+      (is (not (game-mode/end-game? game-on-deploy)))
       (is (= :deploy (game/state final-game)))))
 
   (testing "game is not finished even if it is in deploy state as a string"
     (let [game-on-deploy (-> (game/random) (assoc :state "deploy"))
           final-game (game-mode/process game-on-deploy)]
-      (is (not (game-mode/final? game-on-deploy)))
+      (is (not (game-mode/end-game? game-on-deploy)))
       (is (= "deploy" (game/state final-game))))))
 
 (deftest annihilation-winner

--- a/test/obb_rules/game_mode_test.cljc
+++ b/test/obb_rules/game_mode_test.cljc
@@ -17,6 +17,8 @@
                       (board/place-element [1 1] p1-element)
                       (board/place-element [1 2] p2-element)
                       (game-mode/process)))
+(def game-with-empty-board
+  (game/new-game {}))
 
 (deftest game-processing
   (testing "switch current player using a string"
@@ -42,3 +44,16 @@
           final-game (game-mode/process game-on-deploy)]
       (is (not (game-mode/final? game-on-deploy)))
       (is (= "deploy" (game/state final-game))))))
+
+(deftest annihilation-winner
+  (testing "draw when all players have an empty board"
+     (is (= :draw (game-mode/winner game-with-empty-board))))
+  (let [game-with-empty-p1 (-> (game/new-game {})
+                               (board/place-element [1 2] p2-element))
+        winner             (game-mode/winner game-with-empty-p1)]
+    (testing "the winner is returned"
+      (is (= :p2 winner)))
+    (testing "the winner does not have an empty board"
+      (is (not (board/empty-board? game-with-empty-p1 winner))))
+    (testing "the loser has an empty board"
+      (is (board/empty-board? game-with-empty-p1 :p1)))))

--- a/test/obb_rules/game_mode_test.cljc
+++ b/test/obb_rules/game_mode_test.cljc
@@ -3,47 +3,16 @@
     [obb-rules.game :as game]
     [obb-rules.board :as board]
     [obb-rules.game-mode :as game-mode]
-    [obb-rules.element :as element]
     [obb-rules.unit :as unit]
-    [obb-rules.stash :as stash]
+    [obb-rules.element :as element]
     #?(:clj [clojure.test :refer [deftest testing is run-tests]]
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 
 (def rain (unit/get-unit-by-name "rain"))
-(def p1-element (element/create-element "p1" rain 20 :south))
+
 (def p2-element (element/create-element "p2" rain 20 :south))
-(def running-game (-> (game/random)
-                      (assoc :state "p1")
-                      (board/place-element [1 1] p1-element)
-                      (board/place-element [1 2] p2-element)
-                      (game-mode/process)))
-(def game-with-empty-board
-  (game/new-game {}))
 
-(deftest game-processing
-  (testing "switch current player using a string"
-    (let [game (-> running-game
-                   (assoc :state "p1")
-                   (game-mode/process))]
-      (is (= :p2 (get game :state)))))
-
-  (testing "switch current player using a keyword"
-    (let [game (-> running-game
-                   (assoc :state :p1)
-                   (game-mode/process))]
-      (is (= :p2 (get game :state)))))
-
-  (testing "game is not finished while in deploy state"
-    (let [game-on-deploy (game/random)
-          final-game (game-mode/process game-on-deploy)]
-      (is (not (game-mode/end-game? game-on-deploy)))
-      (is (= :deploy (game/state final-game)))))
-
-  (testing "game is not finished even if it is in deploy state as a string"
-    (let [game-on-deploy (-> (game/random) (assoc :state "deploy"))
-          final-game (game-mode/process game-on-deploy)]
-      (is (not (game-mode/end-game? game-on-deploy)))
-      (is (= "deploy" (game/state final-game))))))
+(def game-with-empty-board (game/new-game {}))
 
 (deftest annihilation-winner
   (testing "draw when all players have an empty board"

--- a/test/obb_rules/game_mode_test.cljc
+++ b/test/obb_rules/game_mode_test.cljc
@@ -1,6 +1,7 @@
 (ns obb-rules.game-mode-test
   (:require
     [obb-rules.game :as game]
+    [obb-rules.game-progress :as game-progress]
     [obb-rules.board :as board]
     [obb-rules.game-mode :as game-mode]
     [obb-rules.unit :as unit]
@@ -12,12 +13,12 @@
 
 (def p2-element (element/create-element "p2" rain 20 :south))
 
-(def game-with-empty-board (game/new-game {}))
+(def game-with-empty-board (game-progress/new-game {}))
 
 (deftest annihilation-winner
   (testing "draw when all players have an empty board"
      (is (= :draw (game-mode/winner game-with-empty-board))))
-  (let [game-with-empty-p1 (-> (game/new-game {})
+  (let [game-with-empty-p1 (-> (game-progress/new-game {})
                                (board/place-element [1 2] p2-element))
         winner             (game-mode/winner game-with-empty-p1)]
     (testing "the winner is returned"
@@ -26,3 +27,12 @@
       (is (not (board/empty-board? game-with-empty-p1 winner))))
     (testing "the loser has an empty board"
       (is (board/empty-board? game-with-empty-p1 :p1)))))
+
+(deftest supernova-on-new-game
+  (testing "star unit is automatically added to the stash"
+    (let [game           {:stash {:p1 {} :p2 {}} :mode :supernova}
+          resulting-game (game-mode/on-new-game game)]
+      (is (empty? (board/get-stash game :p1)))
+      (is (empty? (board/get-stash game :p2)))
+      (is (not-empty (board/get-stash resulting-game :p1)))
+      (is (not-empty (board/get-stash resulting-game :p2))))))

--- a/test/obb_rules/game_progress_test.cljc
+++ b/test/obb_rules/game_progress_test.cljc
@@ -1,0 +1,48 @@
+(ns obb-rules.game-progress-test
+  (:require [obb-rules.game-progress :as game-progress]
+            [obb-rules.game :as game]
+            [obb-rules.element :as element]
+            [obb-rules.unit :as unit]
+            [obb-rules.board :as board]
+            #?(:clj [clojure.test :refer [deftest testing is]]
+               :cljs [cljs.test :refer-macros [deftest testing is]])))
+
+(def rain (unit/get-unit-by-name "rain"))
+
+(def p1-element (element/create-element "p1" rain 20 :south))
+
+(def p2-element (element/create-element "p2" rain 20 :south))
+
+(def running-game (-> (game/random)
+                      (assoc :state "p1")
+                      (board/place-element [1 1] p1-element)
+                      (board/place-element [1 2] p2-element)
+                      (game-progress/next-stage)))
+
+(deftest game-stages
+  (testing "switch current player using a string"
+    (let [game (-> running-game
+                   (assoc :state "p1")
+                   (game-progress/next-stage))]
+      (is (= :p2 (get game :state)))))
+
+  (testing "switch current player using a keyword"
+    (let [game (-> running-game
+                   (assoc :state :p1)
+                   (game-progress/next-stage))]
+      (is (= :p2 (get game :state)))))
+
+  (testing "game is not finished while in deploy state"
+    (let [game-on-deploy (game/random)
+          final-game (game-progress/next-stage game-on-deploy)]
+      (is (not (game-progress/end-game? game-on-deploy)))
+      (is (= :deploy (game/state final-game)))))
+
+  (testing "game is not finished even if it is in deploy state as a string"
+    (let [game-on-deploy (-> (game/random) (assoc :state "deploy"))
+          final-game (game-progress/next-stage game-on-deploy)]
+      (is (not (game-progress/end-game? game-on-deploy)))
+      (is (= "deploy" (game/state final-game))))))
+
+
+

--- a/test/obb_rules/game_progress_test.cljc
+++ b/test/obb_rules/game_progress_test.cljc
@@ -13,7 +13,7 @@
 
 (def p2-element (element/create-element "p2" rain 20 :south))
 
-(def running-game (-> (game/random)
+(def running-game (-> (game-progress/new-random-game)
                       (assoc :state "p1")
                       (board/place-element [1 1] p1-element)
                       (board/place-element [1 2] p2-element)
@@ -33,13 +33,13 @@
       (is (= :p2 (get game :state)))))
 
   (testing "game is not finished while in deploy state"
-    (let [game-on-deploy (game/random)
+    (let [game-on-deploy (game-progress/new-random-game)
           final-game (game-progress/next-stage game-on-deploy)]
       (is (not (game-progress/end-game? game-on-deploy)))
       (is (= :deploy (game/state final-game)))))
 
   (testing "game is not finished even if it is in deploy state as a string"
-    (let [game-on-deploy (-> (game/random) (assoc :state "deploy"))
+    (let [game-on-deploy (-> (game-progress/new-random-game) (assoc :state "deploy"))
           final-game (game-progress/next-stage game-on-deploy)]
       (is (not (game-progress/end-game? game-on-deploy)))
       (is (= "deploy" (game/state final-game))))))

--- a/test/obb_rules/game_test.cljc
+++ b/test/obb_rules/game_test.cljc
@@ -88,3 +88,12 @@
       (is (= 0 (result/result-cost result)))
       (is (= "ActionFailed" (result/result-message result)))
       (is (result/failed? result)))))
+
+(deftest stash-updating
+  (let [game           (game/new-game {:p1 {:rain 1}})
+        update-fn      stash/add-units
+        update-fn-args {:crusader 2}]
+    (testing "the result is the same as applying the function directly to the stash"
+      (let [actual-game (game/update-stash game :p1 update-fn update-fn-args)]
+        (is (= (update-fn (board/get-stash game :p1) update-fn-args)
+               (board/get-stash actual-game :p1)))))))

--- a/test/obb_rules/game_test.cljc
+++ b/test/obb_rules/game_test.cljc
@@ -1,5 +1,6 @@
 (ns obb-rules.game-test
   (:require [obb-rules.game :as game]
+            [obb-rules.game-progress :as game-progress]
             [obb-rules.board :as board]
             [obb-rules.turn :as turn]
             [obb-rules.element :as element]
@@ -13,22 +14,22 @@
 
 (deftest create-game
   (testing "initial game status"
-    (let [game (game/random)]
+    (let [game (game-progress/new-random-game)]
       (is (= :deploy (game/state game)))
       (is (= 0 (board/board-elements-count game)))
       (is (not (stash/cleared? game)))))
 
   (testing "default game mode"
-    (is (= :annihilation (-> (game/new-game {})
+    (is (= :annihilation (-> (game-progress/new-game {})
                              (game/mode)))))
 
   (testing "non-default game mode"
-    (let [game (game/new-game {} {:mode :supernova})]
+    (let [game (game-progress/new-game {} {:mode :supernova})]
       (is (= :supernova (game/mode game))))))
 
 (deftest complete-game-processing
   (let [stash   (stash/create "kamikaze" 1)
-        game    (game/new-game {:p1 stash :p2 stash})
+        game    (game-progress/new-game {:p1 stash :p2 stash})
         result2 (turn/process game :p1 [:deploy 1 :kamikaze [1 7]])
         game2   (result/result-board result2)
         result3 (turn/process game2 :p2 [:deploy 1 :kamikaze [1 2]])
@@ -90,7 +91,7 @@
       (is (result/failed? result)))))
 
 (deftest stash-updating
-  (let [game           (game/new-game {:p1 {:rain 1}})
+  (let [game           (game-progress/new-game {:p1 {:rain 1}})
         update-fn      stash/add-units
         update-fn-args {:crusader 2}]
     (testing "the result is the same as applying the function directly to the stash"

--- a/test/obb_rules/game_test.cljc
+++ b/test/obb_rules/game_test.cljc
@@ -6,6 +6,7 @@
             [obb-rules.unit :as unit]
             [obb-rules.result :as result]
             [obb-rules.game-mode :as game-mode]
+            [obb-rules.game-progress :as game-progress]
             [obb-rules.stash :as stash]
     #?(:clj [clojure.test :refer [deftest testing is run-tests]]
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
@@ -38,7 +39,7 @@
     (is (result/succeeded? result3))
     (is (stash/cleared? (game/get-stash game4 :p2)))
     (is (stash/cleared? (game/get-stash game4 :p1)))
-    (is (= false (game-mode/end-game? game4)))
+    (is (= false (game-progress/end-game? game4)))
 
     (let [game4 (game/state game4 :p1)
           result (turn/process game4 :p1 [:move [1 7] [1 6] 1]
@@ -54,7 +55,7 @@
       (is (= 5 (result/result-cost result)))
 
       (let [mode (game/mode battle)]
-        (is (= true (game-mode/end-game? battle)))
+        (is (= true (game-progress/end-game? battle)))
         (is (= :final (game/state battle)))
         (is (= :annihilation mode))
         (is (= :p1 (game-mode/winner battle)))))))

--- a/test/obb_rules/game_test.cljc
+++ b/test/obb_rules/game_test.cljc
@@ -11,11 +11,19 @@
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 
 (deftest create-game
-  (let [game (game/random)]
-    (is game)
-    (is (= :deploy (game/state game)))
-    (is (= 0 (board/board-elements-count game)))
-    (is (not (stash/cleared? game)))))
+  (testing "initial game status"
+    (let [game (game/random)]
+      (is (= :deploy (game/state game)))
+      (is (= 0 (board/board-elements-count game)))
+      (is (not (stash/cleared? game)))))
+
+  (testing "default game mode"
+    (is (= :annihilation (-> (game/new-game {})
+                             (game/mode)))))
+
+  (testing "non-default game mode"
+    (let [game (game/new-game {} {:mode :supernova})]
+      (is (= :supernova (game/mode game))))))
 
 (deftest complete-game-processing
   (let [stash   (stash/create "kamikaze" 1)
@@ -48,7 +56,7 @@
       (let [mode (game/mode battle)]
         (is (= true (game-mode/end-game? battle)))
         (is (= :final (game/state battle)))
-        (is (= :default mode))
+        (is (= :annihilation mode))
         (is (= :p1 (game-mode/winner battle)))))))
 
 (deftest ensure-max-action-points

--- a/test/obb_rules/game_test.cljc
+++ b/test/obb_rules/game_test.cljc
@@ -18,13 +18,13 @@
     (is (not (stash/cleared? game)))))
 
 (deftest complete-game-processing
-  (let [stash (stash/create "kamikaze" 1)
-        game (game/create stash)
+  (let [stash   (stash/create "kamikaze" 1)
+        game    (game/new-game {:p1 stash :p2 stash})
         result2 (turn/process game :p1 [:deploy 1 :kamikaze [1 7]])
-        game2 (result/result-board result2)
+        game2   (result/result-board result2)
         result3 (turn/process game2 :p2 [:deploy 1 :kamikaze [1 2]])
-        game3 (result/result-board result3)
-        game4 game3]
+        game3   (result/result-board result3)
+        game4   game3]
     (is (not= :deploy (game/state game4)))
     (is (result/succeeded? result2))
     (is (result/succeeded? result3))

--- a/test/obb_rules/game_test.cljc
+++ b/test/obb_rules/game_test.cljc
@@ -30,7 +30,7 @@
     (is (result/succeeded? result3))
     (is (stash/cleared? (game/get-stash game4 :p2)))
     (is (stash/cleared? (game/get-stash game4 :p1)))
-    (is (= false (game-mode/final? game4)))
+    (is (= false (game-mode/end-game? game4)))
 
     (let [game4 (game/state game4 :p1)
           result (turn/process game4 :p1 [:move [1 7] [1 6] 1]
@@ -46,7 +46,7 @@
       (is (= 5 (result/result-cost result)))
 
       (let [mode (game/mode battle)]
-        (is (= true (game-mode/final? battle)))
+        (is (= true (game-mode/end-game? battle)))
         (is (= :final (game/state battle)))
         (is (= :default mode))
         (is (= :p1 (game-mode/winner battle)))))))

--- a/test/obb_rules/privatize_test.cljc
+++ b/test/obb_rules/privatize_test.cljc
@@ -1,6 +1,7 @@
 (ns obb-rules.privatize-test
   (:require
     [obb-rules.game :as game]
+    [obb-rules.game-progress :as game-progress]
     [obb-rules.board :as board]
     [obb-rules.privatize :as privatize]
     [obb-rules.unit :as unit]
@@ -11,7 +12,7 @@
        :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 
 (def rain (unit/get-unit-by-name "rain"))
-(def deploy-game (game/random))
+(def deploy-game (game-progress/new-random-game))
 (def final-board (assoc deploy-game :state "final"))
 (def p1-board (assoc deploy-game :state :p1))
 (def p2-board (assoc deploy-game :state "p2"))

--- a/test/obb_rules/serializer/reader_test.cljc
+++ b/test/obb_rules/serializer/reader_test.cljc
@@ -4,6 +4,7 @@
     [obb-rules.serializer.writer :as writer]
     [obb-rules.stash :as stash]
     [obb-rules.game :as game]
+    [obb-rules.game-progress :as game-progress]
     [obb-rules.turn :as turn]
     [obb-rules.result :as result]
     [obb-rules.board :as board]
@@ -76,7 +77,7 @@
 (deftest complete-game
   (test-game (-> {:p1 (stash/create :kamikaze 1)
                   :p2 (stash/create :kamikaze 1)}
-                 game/new-game
+                 game-progress/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]])
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]])
@@ -90,7 +91,7 @@
 (deftest not-complete-game
   (test-game (-> {:p1 (stash/create :kamikaze 1)
                   :p2 (stash/create :kamikaze 1)}
-                 game/new-game
+                 game-progress/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]])
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]])
@@ -103,21 +104,21 @@
 (deftest just-player-1-deployed
   (test-game (-> {:p1 (stash/create :kamikaze 1)
                   :p2 (stash/create :kamikaze 1)}
-                 game/new-game
+                 game-progress/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]]))))
 
 (deftest just-player-2-deployed
   (test-game (-> {:p1 (stash/create :kamikaze 1)
                   :p2 (stash/create :kamikaze 1)}
-                 game/new-game
+                 game-progress/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]]))))
 
 (deftest game-ready-to-start
   (test-game (-> {:p1 (stash/create :kamikaze 1)
                   :p2 (stash/create :kamikaze 1)}
-                 game/new-game
+                 game-progress/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]])
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]])
@@ -133,7 +134,7 @@
 (deftest allow-white-spaces
   (let [game (-> {:p1 (stash/create :kamikaze 1)
                   :p2 (stash/create :kamikaze 1)}
-                 game/new-game
+                 game-progress/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]])
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]])

--- a/test/obb_rules/serializer/reader_test.cljc
+++ b/test/obb_rules/serializer/reader_test.cljc
@@ -74,8 +74,9 @@
     (is (= game loaded-game))))
 
 (deftest complete-game
-  (test-game (-> (stash/create :kamikaze 1)
-                 game/create
+  (test-game (-> {:p1 (stash/create :kamikaze 1)
+                  :p2 (stash/create :kamikaze 1)}
+                 game/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]])
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]])
@@ -87,8 +88,9 @@
                                          [:attack [1 3] [1 2]]))))
 
 (deftest not-complete-game
-  (test-game (-> (stash/create :kamikaze 1)
-                 game/create
+  (test-game (-> {:p1 (stash/create :kamikaze 1)
+                  :p2 (stash/create :kamikaze 1)}
+                 game/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]])
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]])
@@ -99,20 +101,23 @@
                                          [:move [1 4] [1 3] 1]))))
 
 (deftest just-player-1-deployed
-  (test-game (-> (stash/create :kamikaze 1)
-                 game/create
+  (test-game (-> {:p1 (stash/create :kamikaze 1)
+                  :p2 (stash/create :kamikaze 1)}
+                 game/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]]))))
 
 (deftest just-player-2-deployed
-  (test-game (-> (stash/create :kamikaze 1)
-                 game/create
+  (test-game (-> {:p1 (stash/create :kamikaze 1)
+                  :p2 (stash/create :kamikaze 1)}
+                 game/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]]))))
 
 (deftest game-ready-to-start
-  (test-game (-> (stash/create :kamikaze 1)
-                 game/create
+  (test-game (-> {:p1 (stash/create :kamikaze 1)
+                  :p2 (stash/create :kamikaze 1)}
+                 game/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]])
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]])
@@ -126,8 +131,9 @@
       (test-game (:board result)))))
 
 (deftest allow-white-spaces
-  (let [game (-> (stash/create "kamikaze" 1)
-                 game/create
+  (let [game (-> {:p1 (stash/create :kamikaze 1)
+                  :p2 (stash/create :kamikaze 1)}
+                 game/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]])
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]])

--- a/test/obb_rules/serializer/writer_test.cljc
+++ b/test/obb_rules/serializer/writer_test.cljc
@@ -3,6 +3,7 @@
     [obb-rules.serializer.writer :as writer]
     [obb-rules.stash :as stash]
     [obb-rules.game :as game]
+    [obb-rules.game-progress :as game-progress]
     [obb-rules.turn :as turn]
     [obb-rules.result :as result]
     [obb-rules.board :as board]
@@ -29,7 +30,7 @@
 (deftest complete-game
   (let [game (-> {:p1 (stash/create :kamikaze 1)
                   :p2 (stash/create :kamikaze 1)}
-                 game/new-game
+                 game-progress/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]])
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]])
@@ -53,7 +54,7 @@ p1 m1716.1 m1615.1 m1514.1 m1413.1 a1312"))))
 (deftest add-stash-to-props-if-deploy-state
   (let [game (-> {:p1 (stash/create :kamikaze 1)
                   :p2 (stash/create :kamikaze 1)}
-                 game/new-game
+                 game-progress/new-game
                  (board/board-terrain :ice))]
     (is (= (writer/game->str game)
 "terrain: ice
@@ -68,7 +69,7 @@ state: deploy
 (deftest add-stash-to-props-if-player-1-deployed
   (let [game (-> {:p1 (stash/create :kamikaze 1)
                   :p2 (stash/create :kamikaze 1)}
-                 game/new-game
+                 game-progress/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]]))]
     (is (= (writer/game->str game)
@@ -83,7 +84,7 @@ p1 d17.1.kamikaze
 (deftest add-stash-to-props-if-player-2-deployed
   (let [game (-> {:p1 (stash/create :kamikaze 1)
                   :p2 (stash/create :kamikaze 1)}
-                 game/new-game
+                 game-progress/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]]))]
     (is (= (writer/game->str game)

--- a/test/obb_rules/serializer/writer_test.cljc
+++ b/test/obb_rules/serializer/writer_test.cljc
@@ -27,8 +27,9 @@
                                  [:rotate [1 1] :west]]))))
 
 (deftest complete-game
-  (let [game (-> (stash/create "kamikaze" 1)
-                 game/create
+  (let [game (-> {:p1 (stash/create :kamikaze 1)
+                  :p2 (stash/create :kamikaze 1)}
+                 game/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]])
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]])
@@ -50,8 +51,9 @@ p2 d12.1.kamikaze
 p1 m1716.1 m1615.1 m1514.1 m1413.1 a1312"))))
 
 (deftest add-stash-to-props-if-deploy-state
-  (let [game (-> (stash/create "kamikaze" 1)
-                 game/create
+  (let [game (-> {:p1 (stash/create :kamikaze 1)
+                  :p2 (stash/create :kamikaze 1)}
+                 game/new-game
                  (board/board-terrain :ice))]
     (is (= (writer/game->str game)
 "terrain: ice
@@ -64,8 +66,9 @@ state: deploy
 "))))
 
 (deftest add-stash-to-props-if-player-1-deployed
-  (let [game (-> (stash/create "kamikaze" 1)
-                 game/create
+  (let [game (-> {:p1 (stash/create :kamikaze 1)
+                  :p2 (stash/create :kamikaze 1)}
+                 game/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p1 [:deploy 1 :kamikaze [1 7]]))]
     (is (= (writer/game->str game)
@@ -78,8 +81,9 @@ p1 d17.1.kamikaze
 "))))
 
 (deftest add-stash-to-props-if-player-2-deployed
-  (let [game (-> (stash/create "kamikaze" 1)
-                 game/create
+  (let [game (-> {:p1 (stash/create :kamikaze 1)
+                  :p2 (stash/create :kamikaze 1)}
+                 game/new-game
                  (board/board-terrain :ice)
                  (turn/process-board :p2 [:deploy 1 :kamikaze [1 2]]))]
     (is (= (writer/game->str game)

--- a/test/obb_rules/stash_test.cljc
+++ b/test/obb_rules/stash_test.cljc
@@ -63,3 +63,10 @@
     (is (= 9 (stash/how-many? stash4 :crusader)))
     (is (= 9 (stash/how-many? stash5 "crusader")))))
 
+(deftest adding-units
+  (let [stash (stash/create :rain 10)]
+    (testing "adding a non existing unit type"
+      (is (= 1 (stash/how-many? (stash/add-units stash {:crusader 1}) :crusader))))
+    (testing "adding an already existing unit type"
+      (is (= 20 (stash/how-many? (stash/add-units stash {:rain 10}) :rain))))))
+

--- a/test/obb_rules/unit_test.cljc
+++ b/test/obb_rules/unit_test.cljc
@@ -4,9 +4,9 @@
     #?(:clj [clojure.test :refer [deftest testing is]]
        :cljs [cljs.test :refer-macros [deftest testing is]])))
 
-(deftest unit-smoke
+(deftest existing-unit-types
   (testing "get-units"
-    (is (= 20 (count (unit/get-units))))))
+    (is (= 21 (count (unit/get-units))))))
 
 (defn- test-unit
   [name code]
@@ -21,7 +21,7 @@
 
 (defn- verify-unit
   [unit]
-  (testing  (test-unit (:name unit) (:code unit))))
+  (testing (test-unit (:name unit) (:code unit))))
 
 (deftest verify-units
   (doseq [unit (unit/get-units)]


### PR DESCRIPTION
While the concept of game modes already existed in the codebase, all the definitions were still specific to the Annihilation game mode. In this PR those concepts are generalised, making it easy to support other game modes, and an implementation for the Supernova game mode is added.