### PR TITLE
Allow reload of a custom text game on the player

### DIFF
--- a/src/obb_demo/views/player.cljs
+++ b/src/obb_demo/views/player.cljs
@@ -8,6 +8,7 @@
             [obb-rules.unit :as unit]
             [obb-rules.host-dependent :as host]
             [obb-rules.serializer.writer :as writer]
+            [obb-rules.serializer.reader :as reader]
             [obb-demo.processor :as processor]
             [obb-demo.views.power-bar :as power-bar]
             [obb-rules.ai.firingsquad :as firingsquad]
@@ -248,10 +249,31 @@
    [:option "Firingsquad"]
    [:option "Alamo"]])
 
+(defn- game-str-changed
+  "Called then the textarea with the game str is changed by the user"
+  [game-data ev]
+  (state/set-page-data! (assoc game-data :game-str (-> ev .-target .-value))))
+
+(defn- load-game-str
+  "Loads the game from a string on the game data"
+  [game-data]
+  (let [game-str (:game-str game-data)
+        new-game (reader/str->game game-str)]
+    (state/set-page-data!
+      (-> game-data
+          (dissoc :game-str)
+          (assoc :game new-game)))))
+
 (defn- game-as-string
   [game-data]
-  [:pre {:style {:margin-top "10px"}}
-    (writer/game->str (:game game-data))])
+  [:div.row
+    [:textarea {:style {:margin-top "10px"
+                        :height "500px"}
+                :class "form-control"
+                :on-change (partial game-str-changed game-data)
+                :value (or (:game-str game-data)
+                           (writer/game->str (:game game-data)))}]
+    [:button.btn.btn-primary {:on-click (partial load-game-str game-data)} "Load"]])
 
 (defn render
   [state]


### PR DESCRIPTION
Before, the current game was being written as text on the game, on each turn.
Now, I replaced the raw text with an editable textarea and added a load
button. If the textarea is changed, that new str is stored, and when the
button is pressed the current game is replaced with the loaded one.

<img width="717" alt="screen shot 2016-03-24 at 08 45 23" src="https://cloud.githubusercontent.com/assets/483669/14012308/edea6ea2-f19c-11e5-8008-04413979495f.png">


Still has some issues (sometimes the Ai doesn't play on a loaded game), but
it's already a great way to have a visual representation of any game.